### PR TITLE
Set input width for iOS

### DIFF
--- a/style.css
+++ b/style.css
@@ -1287,6 +1287,15 @@ input[type="submit"] {
 	#main {
 		padding-top: 35px;
 	}
+	input[type="text"],
+	input[type="email"],
+	input[type="url"],
+	input[type="search"],
+	input[type="tel"],
+	input[type="password"],
+	textarea {
+		font-size: 16px;
+	}
 	#respond input[type="text"],
 	#respond input[type="email"],
 	#respond input[type="url"] {


### PR DESCRIPTION
By setting the input and textarea width to 16px on mobile devices, iOS devices will not zoom in when tapping to enter text into these fields.