### PR TITLE
Center gallery images

### DIFF
--- a/style.css
+++ b/style.css
@@ -1480,8 +1480,9 @@ object {
 .gallery-item img {
 	display: block;
 	width: 100%;
-	padding-right: 5%;
+	padding-right: 2.5%;
 	padding-bottom: 5%;
+	padding-right: 2.5%;
 }
 
 .gallery-columns-1 .gallery-item img {


### PR DESCRIPTION
Currently, 5% padding is added to the right side of gallery images. This change places 2.5% padding on the left and right instead, so that image galleries are centered on pages.