### PR TITLE
Call correct paging_nav function

### DIFF
--- a/templates/full-width-portfolio.php
+++ b/templates/full-width-portfolio.php
@@ -60,7 +60,7 @@ $portfolio = new WP_Query( $args );
 
 			<?php endwhile; ?>
 
-			<?php portfolioplus_paging_nav( $portfolio ); ?>
+			<?php portfoliopress_paging_nav( $portfolio ); ?>
 
 		<?php else : ?>
 			<?php get_template_part( 'content', 'none' ); ?>


### PR DESCRIPTION
The error is at the bottom of the page, so the page appeared to load fine, but threw a 500 error before displaying the nav. Been broken for about 4 years it seems.